### PR TITLE
Restore batch mode and update documentation after repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,28 @@ Author: **Carlo Zannini**
 
 ### Standard Installation
 
+> **Repository and package name**
+> Repository, working directory and importable package all share the same
+> name, `pytlwall`. The repository was previously called `TLWallNew`; old
+> links still redirect, but the current name is `pytlwall`.
+> Do not confuse it with `pytlwall-v1`, which holds the superseded v1
+> codebase and is kept for reference only.
+
 ```bash
-# Clone repository
-git clone https://github.com/CERN/pytlwall.git
+# Clone the repository
+git clone https://github.com/tatianarijoff/pytlwall.git
 cd pytlwall
 
 # Install package
 pip install .
 ```
+
+### Sources
+
+| Source | URL | Status |
+|--------|-----|--------|
+| **pytlwall** (current) | https://github.com/tatianarijoff/pytlwall | Active development |
+| pytlwall-v1 (legacy) | https://github.com/tatianarijoff/pytlwall-v1 | Superseded, reference only |
 
 ### Development Installation
 
@@ -73,6 +87,31 @@ pip install -e .
 # Install with all dependencies
 pip install -e ".[dev,gui]"
 ```
+
+### Virtual Environment (recommended)
+
+On Debian, Ubuntu and other distributions that ship an externally managed
+Python, `pip install` against the system interpreter is refused with
+`error: externally-managed-environment` (PEP 668). Install into a virtual
+environment instead:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+The shell prompt is prefixed with `(.venv)` while the environment is active.
+Reactivate it in every new terminal with `source .venv/bin/activate`, and
+leave it with `deactivate`.
+
+If `python3 -m venv` fails, install the system package first:
+`sudo apt install python3-venv`.
+
+Note that Debian and Ubuntu provide `python3` only: a bare `python` command
+does not exist outside an activated virtual environment.
+
+On Windows the activation command is `.venv\Scripts\activate`.
 
 ### Conda Environment
 
@@ -171,12 +210,42 @@ mc.plot_totals(show=False)
 ### Command Line Interface
 
 ```bash
-# Run with configuration file
+# Batch mode: run a full calculation from a configuration file
+python -m pytlwall -a config.cfg
+
+# Equivalent short form (a bare .cfg is treated as batch mode)
 python -m pytlwall config.cfg
+
+# Interactive text interface
+python -m pytlwall -i
 
 # Launch GUI
 python -m pytlwall --gui
+
+# Version
+python -m pytlwall --version
 ```
+
+After `pip install .` the same commands are available through the
+`pytlwall` console script, e.g. `pytlwall -a config.cfg`.
+
+> **Batch mode requires output sections.**
+> `-a` executes the full pipeline: build the chamber/beam/frequency objects,
+> compute the impedances, write the data files, produce the plots. The
+> impedances to compute are taken from the `[output]` section, the data files
+> from `[output1]`, `[output2]`, … and the images from `[img_output1]`,
+> `[img_output2]`, …
+> A configuration file containing only `[base_info]`, `[layers_info]`,
+> `[boundary]`, `[frequency_info]` and `[beam_info]` is a valid *model*
+> definition but produces no output in batch mode; the run exits with a
+> warning. Most files under `examples/` are of this kind and are meant to be
+> loaded from Python or from the GUI.
+> `examples/ex_run_exec/ex_lowbeta.cfg` is the reference example of a
+> complete, directly runnable configuration.
+
+Relative output paths in the configuration are interpreted with respect to
+the current working directory, unless a `[path_info]` section defines
+`main_path`, in which case they are resolved against it.
 
 ### Launch GUI Directly
 
@@ -321,14 +390,112 @@ RQ = 0
 type = PEC
 
 [frequency_info]
-fmin = 1e3
-fmax = 1e9
-fstep = 10
+; fmin/fmax are DECIMAL EXPONENTS (10^fmin .. 10^fmax), not frequencies in Hz.
+; fstep is the number of points per decade exponent.
+fmin = 3
+fmax = 9
+fstep = 2
 
 [beam_info]
 gammarel = 7460.52
 test_beam_shift = 0.001
+
+; --- the sections below are what makes the file runnable with -a ---
+
+[output]
+; which impedances to compute; anything absent or False is skipped
+ZLong = True
+ZTrans = True
+ZLongSurf = True
+
+[output1]
+; allowed extensions: .txt, .csv, .dat, .xlsx
+output_name = out/arc_chamber.xlsx
+; prepend component_name to each column label
+use_name_flag = True
+output_list = ZLong, ZTrans, ZLongSurf
+re_im_flag = both
+
+[img_output1]
+img_name = out/arc_chamber_long.png
+use_name_flag = False
+imped_list = ZLong
+re_im_flag = both
+title = Longitudinal impedance
+; lin | log | symlog
+xscale = log
+yscale = lin
 ```
+
+Minimal end-to-end check:
+
+```bash
+python -m pytlwall -a examples/ex_run_exec/ex_lowbeta.cfg
+```
+
+This writes `low_beta.xlsx`, `low_beta_long.txt` and `low_beta_long.png`
+into `examples/ex_run_exec/`.
+
+---
+
+## Testing
+
+The test suite lives in `tests/` and is run with pytest.
+
+```bash
+# Install the test dependencies (pytest, pytest-cov)
+pip install -e ".[test]"
+
+# Run the whole suite
+pytest
+```
+
+Expected result on a clean checkout:
+
+```
+362 passed, 3 skipped
+```
+
+The three skips are expected: `tests/test_cfgio_realistic.py` contains cases
+that require the fixture files `test_round.cfg` and `test_rect.cfg`, which are
+not distributed with the repository. Anything other than a skip is a genuine
+failure.
+
+Coverage is enabled by default through `[tool.pytest.ini_options]` in
+`pyproject.toml`: a summary is printed to the terminal and a browsable HTML
+report is written to `htmlcov/index.html`. Both `.coverage` and `htmlcov/`
+are excluded from version control.
+
+### Running a subset
+
+```bash
+# One file
+pytest tests/test_tlwall.py
+
+# One test
+pytest tests/test_tlwall.py::TestTlWall::test_calc_ZLong
+
+# Verbose, stop at the first failure
+pytest -v -x
+
+# Skip the coverage report (faster)
+pytest --no-cov
+```
+
+### Headless machines
+
+`tests/test_plot.py` builds Matplotlib figures. On a machine without a
+display, force a non-interactive backend:
+
+```bash
+MPLBACKEND=Agg pytest
+```
+
+### Test documentation
+
+Individual test modules are documented under `tests/doc/`, for example
+[test_cfg.md](tests/doc/test_cfg.md) and
+[test_tlwall_wake.md](doc/testing/test_tlwall_wake.md).
 
 ---
 
@@ -338,10 +505,16 @@ test_beam_shift = 0.001
 
 | Issue | Solution |
 |-------|----------|
+| `error: externally-managed-environment` | System Python is protected (PEP 668); create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate` |
+| `python: command not found` | On Debian/Ubuntu use `python3`, or activate a virtual environment |
 | Import error | Ensure pytlwall is installed: `pip install -e .` |
+| `No module named pytlwall` after cloning | Run `pip install -e .` from inside the cloned `pytlwall` directory |
 | GUI not launching | Install PyQt5: `pip install pyqt5` |
 | Plot not showing | Install Matplotlib: `pip install matplotlib` |
-| Excel export fails | Install openpyxl: `pip install openpyxl` |
+| Batch run prints only the help text | The first argument must be `-a`, `-i`, `--gui` or a `.cfg` path |
+| Batch run produces no files | The `.cfg` has no `[output]` / `[outputN]` / `[img_outputN]` sections |
+| Excel export fails | Install openpyxl and pandas: `pip install openpyxl pandas` |
+| Output written to an unexpected directory | Relative paths follow the working directory unless `[path_info] main_path` is set |
 | Config file error | Check INI format and section names |
 
 ### Getting Help

--- a/doc/API_REFERENCE_CFGIO.md
+++ b/doc/API_REFERENCE_CFGIO.md
@@ -276,11 +276,16 @@ ZLong = wall.calc_ZLong()
 
 Calculate impedances based on configuration.
 
+**Returns:** dict mapping impedance name to its complex array.
+
 **Side Effects:**
-- Sets `self.mywall` and `self.myimped`
+- Sets `self.wall` (the `TlWall` object) and `self.imped` (the results dict).
+- Legacy aliases `self.mywall` / `self.myimped` are also set.
 
 **Note:**
-- Requires `read_output()` called first
+- Calls `read_output()` automatically if no output specification has been read yet.
+- Computes every impedance listed in `[output]` plus any referenced by
+  `[outputN]` / `[img_outputN]`.
 
 **Example:**
 ```python
@@ -295,7 +300,8 @@ Write calculated impedances to files.
 
 **Note:**
 - Requires `calc_wall()` called first
-- Output format based on file extension (.xlsx or .csv)
+- Output format based on file extension (`.txt`, `.csv`, `.dat`, `.xlsx`)
+- Returns the list of paths written
 
 **Example:**
 ```python
@@ -309,7 +315,9 @@ Generate plots of calculated impedances.
 
 **Note:**
 - Requires `calc_wall()` called first
-- Uses `pytlwall.plot_util`
+- Uses `pytlwall.plot_util.plot_list_Z_vs_f`
+- Honours `re_im_flag`, `title`, `xscale`, `yscale` from each `[img_outputN]`
+- Accepts `show=False` (default) to save without opening a window
 
 **Example:**
 ```python

--- a/doc/INSTALLATION.md
+++ b/doc/INSTALLATION.md
@@ -49,7 +49,7 @@ This is the **recommended installation** for most users.
 ### From source
 
 ```bash
-git clone https://github.com/CERN/pytlwall.git
+git clone https://github.com/tatianarijoff/pytlwall.git
 cd pytlwall
 pip install .
 ```
@@ -126,7 +126,7 @@ pytlwall-gui
 For developers and contributors:
 
 ```bash
-git clone https://github.com/CERN/pytlwall.git
+git clone https://github.com/tatianarijoff/pytlwall.git
 cd pytlwall
 pip install -e ".[dev]"
 ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -57,7 +57,7 @@ Author: **Carlo Zannini**
 
 ```bash
 # Clone repository
-git clone https://github.com/CERN/pytlwall.git
+git clone https://github.com/tatianarijoff/pytlwall.git
 cd pytlwall
 
 # Install package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "scipy>=1.7.0",
     "matplotlib>=3.3.0",
     "openpyxl>=3.0.0",
+    "pandas>=1.3.0",
 ]
 
 [project.optional-dependencies]
@@ -85,11 +86,11 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/CERN/pytlwall"
-Documentation = "https://github.com/CERN/pytlwall/blob/main/README.md"
-Repository = "https://github.com/CERN/pytlwall"
-Issues = "https://github.com/CERN/pytlwall/issues"
-Changelog = "https://github.com/CERN/pytlwall/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/tatianarijoff/pytlwall"
+Documentation = "https://github.com/tatianarijoff/pytlwall/blob/main/README.md"
+Repository = "https://github.com/tatianarijoff/pytlwall"
+Issues = "https://github.com/tatianarijoff/pytlwall/issues"
+Changelog = "https://github.com/tatianarijoff/pytlwall/blob/main/CHANGELOG.md"
 
 [project.scripts]
 # Command-line entry point

--- a/pytlwall/cfg_io.py
+++ b/pytlwall/cfg_io.py
@@ -1003,7 +1003,211 @@ class CfgIo:
                 self.img_output[filename]['imped'].append(imped.strip())
             
             i += 1
-    
+
+    # =========================================================================
+    # Batch Orchestration (calc / print / plot)
+    # =========================================================================
+
+    def _resolve_output_path(self, filename: str) -> Path:
+        """
+        Resolve an output filename to a full path.
+
+        Absolute paths are used as-is. Relative paths are resolved against
+        ``main_path`` when the ``[path_info]`` section provides one, otherwise
+        against the current working directory. Parent directories are created.
+
+        Args:
+            filename: Output file name or path from the configuration.
+
+        Returns:
+            Resolved Path object whose parent directory exists.
+        """
+        out_path = Path(filename).expanduser()
+        if not out_path.is_absolute() and self.main_path is not None:
+            out_path = Path(self.main_path).expanduser() / out_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        return out_path
+
+    def _requested_impedances(self) -> List[str]:
+        """Collect every impedance name requested by output/file/img sections."""
+        names: List[str] = list(self.list_output)
+        for spec in self.file_output.values():
+            for name in spec.get('imped', []):
+                if name not in names:
+                    names.append(name)
+        for spec in self.img_output.values():
+            for name in spec.get('imped', []):
+                if name not in names:
+                    names.append(name)
+        return names
+
+    def calc_wall(self, cfg_file: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Build the TlWall object and evaluate every requested impedance.
+
+        This is the batch-mode driver used by ``python -m pytlwall -a cfg``.
+        It reads the configuration, instantiates :class:`TlWall`, and computes
+        all impedances listed in ``[output]`` plus any referenced by the
+        ``[outputN]`` / ``[img_outputN]`` sections.
+
+        Args:
+            cfg_file: Path to configuration file (optional if already loaded).
+
+        Returns:
+            Dictionary mapping impedance name to its complex array.
+
+        Raises:
+            ConfigurationError: If the configuration is incomplete.
+
+        Example:
+            >>> cfg = CfgIo('config.cfg')
+            >>> cfg.read_output()
+            >>> imped = cfg.calc_wall()
+            >>> cfg.print_wall()
+            >>> cfg.plot_wall()
+        """
+        if cfg_file is not None:
+            self.read_cfg(cfg_file)
+
+        # Make sure the output specification has been parsed.
+        if not (self.list_output or self.file_output or self.img_output):
+            self.read_output()
+
+        self.wall = self.read_pytlwall()
+        if self.wall is None:
+            raise ConfigurationError(
+                "Incomplete configuration: chamber, beam and frequency "
+                "sections are all required to build a TlWall object."
+            )
+
+        self.imped: Dict[str, Any] = {}
+        for name in self._requested_impedances():
+            try:
+                self.imped[name] = getattr(self.wall, name)
+            except AttributeError:
+                print(f"Warning: unknown impedance '{name}', skipped.")
+
+        # Legacy attribute names kept for backward compatibility.
+        self.mywall = self.wall
+        self.myimped = self.imped
+
+        return self.imped
+
+    def print_wall(self) -> List[Path]:
+        """
+        Write the computed impedances to the files declared in ``[outputN]``.
+
+        Requires :meth:`calc_wall` to have been called first.
+
+        Returns:
+            List of paths actually written.
+        """
+        from pytlwall.io_util import export_impedance
+
+        if not getattr(self, 'imped', None):
+            raise ConfigurationError("call calc_wall() before print_wall()")
+
+        written: List[Path] = []
+        for filename, spec in self.file_output.items():
+            prefix = spec.get('prefix', '')
+            imped_dict: Dict[str, Any] = {}
+            for name in spec.get('imped', []):
+                if name not in self.imped:
+                    continue
+                label = f"{prefix}_{name}" if prefix else name
+                imped_dict[label] = self.imped[name]
+
+            if not imped_dict:
+                print(f"Warning: nothing to write for '{filename}', skipped.")
+                continue
+
+            out_path = self._resolve_output_path(filename)
+            written.append(
+                export_impedance(
+                    freqs=self.wall.freq,
+                    imped_dict=imped_dict,
+                    output_path=out_path,
+                    save_csv_fallback=True,
+                )
+            )
+            print(f"Written {out_path}")
+
+        return written
+
+    def plot_wall(self, show: bool = False) -> List[Path]:
+        """
+        Produce the plots declared in the ``[img_outputN]`` sections.
+
+        Requires :meth:`calc_wall` to have been called first. The
+        ``re_im_flag`` option selects whether the real part, the imaginary
+        part, or both are drawn.
+
+        Args:
+            show: If True, display the figures interactively.
+
+        Returns:
+            List of image paths written.
+        """
+        import matplotlib.pyplot as plt
+        from pytlwall.plot_util import plot_list_Z_vs_f
+
+        if not getattr(self, 'imped', None):
+            raise ConfigurationError("call calc_wall() before plot_wall()")
+
+        written: List[Path] = []
+        for filename, spec in self.img_output.items():
+            prefix = spec.get('prefix', '')
+            real_imag = spec.get('real_imag', 'both')
+
+            list_Z: List[Any] = []
+            list_label: List[str] = []
+            for name in spec.get('imped', []):
+                if name not in self.imped:
+                    continue
+                Z = self.imped[name]
+                base = f"{prefix}_{name}" if prefix else name
+                if real_imag in ('real', 'both'):
+                    list_Z.append(Z.real)
+                    list_label.append(f"Re({base})")
+                if real_imag in ('imag', 'both'):
+                    list_Z.append(Z.imag)
+                    list_label.append(f"Im({base})")
+
+            if not list_Z:
+                print(f"Warning: nothing to plot for '{filename}', skipped.")
+                continue
+
+            # Pick the unit family from the first requested impedance.
+            first = spec['imped'][0]
+            if 'Surf' in first:
+                imped_type = 'S'
+            elif 'Long' in first:
+                imped_type = 'L'
+            else:
+                imped_type = 'T'
+
+            out_path = self._resolve_output_path(filename)
+            fig = plot_list_Z_vs_f(
+                self.wall.freq,
+                list_Z,
+                list_label,
+                imped_type=imped_type,
+                title=spec.get('title'),
+                savedir=str(out_path.parent),
+                savename=out_path.name,
+                xscale=spec.get('xscale', 'lin'),
+                yscale=spec.get('yscale', 'lin'),
+            )
+            written.append(out_path)
+            print(f"Written {out_path}")
+
+            if show:
+                plt.show()
+            elif fig is not None:
+                plt.close(fig)
+
+        return written
+
     def save_calc(self, list_calc: Dict[str, bool]) -> None:
         """
         Save calculation configuration.

--- a/pytlwall/run_pytlwall.py
+++ b/pytlwall/run_pytlwall.py
@@ -22,8 +22,22 @@ import pytlwall.shell_interface as shell
 
 def _run_batch(cfg_filename: str) -> int:
     """Run a full computation from a configurator file."""
+    import os
+
+    if not os.path.isfile(cfg_filename):
+        print(f"Error: configuration file '{cfg_filename}' not found.")
+        return 2
+
     cfg = pytlwall.CfgIo(cfg_filename)
     cfg.read_output()
+
+    if not (cfg.list_output or cfg.file_output or cfg.img_output):
+        print(
+            f"Warning: '{cfg_filename}' has no [output], [outputN] or "
+            "[img_outputN] section: nothing to compute or save."
+        )
+        return 0
+
     cfg.calc_wall()
     cfg.print_wall()
     cfg.plot_wall()
@@ -150,6 +164,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         # Keep legacy option for compatibility, but point users to the new entry.
         print("GUI mode: use 'python -m pytlwall --gui'")
         return 0
+
+    # Convenience: a bare configuration file is treated as batch mode, so that
+    #     python -m pytlwall config.cfg
+    # behaves like
+    #     python -m pytlwall -a config.cfg
+    if not param.startswith("-"):
+        return _run_batch(param)
 
     shell.help_pytlwall()
     return 2

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,11 @@ setup(
     maintainer_email="tatiana.rijoff@gmail.com",
     
     # URLs
-    url="https://github.com/CERN/pytlwall",
+    url="https://github.com/tatianarijoff/pytlwall",
     project_urls={
-        "Bug Reports": "https://github.com/CERN/pytlwall/issues",
-        "Source": "https://github.com/CERN/pytlwall",
-        "Documentation": "https://github.com/CERN/pytlwall/blob/main/README.md",
+        "Bug Reports": "https://github.com/tatianarijoff/pytlwall/issues",
+        "Source": "https://github.com/tatianarijoff/pytlwall",
+        "Documentation": "https://github.com/tatianarijoff/pytlwall/blob/main/README.md",
     },
     
     # License


### PR DESCRIPTION
## Summary

Batch execution (`python -m pytlwall -a config.cfg`) was broken and has been
restored. This PR also brings the documentation in line with the repository
rename from `TLWallNew` to `pytlwall`.

## The problem

`CfgIo.calc_wall()`, `print_wall()` and `plot_wall()` were removed during the
refactoring, but `run_pytlwall._run_batch()` still called them. Every batch run
failed immediately:

```
Error in console mode: 'CfgIo' object has no attribute 'calc_wall'
```

The computation engine itself was unaffected — only the orchestration layer
between the configuration file and the output was missing.

## Functional changes

**`pytlwall/cfg_io.py`**
- Reimplement `calc_wall()`, `print_wall()` and `plot_wall()` against the
  current API.
- `calc_wall()` builds the `TlWall` object and evaluates every impedance
  listed in `[output]` plus any referenced by `[outputN]` / `[img_outputN]`.
  It reads the output specification automatically when not already loaded.
- `print_wall()` writes each `[outputN]` file and returns the paths written;
  `plot_wall()` honours `re_im_flag`, `title`, `xscale` and `yscale`.
- Add the `_resolve_output_path()` and `_requested_impedances()` helpers.
- Keep the legacy `mywall` / `myimped` attribute aliases for backward
  compatibility.

**`pytlwall/run_pytlwall.py`**
- Check that the configuration file exists before parsing it.
- Warn instead of failing silently when a configuration declares no output
  section.
- Accept a bare `.cfg` path, so `python -m pytlwall config.cfg` behaves like
  `python -m pytlwall -a config.cfg`.

**`pyproject.toml`**
- Declare the `pandas` dependency. It is required by the `.xlsx` export path
  in `io_util` but was missing, so a clean install could not run the shipped
  example.

## Documentation changes

- Fix repository URLs in `README.md`, `setup.py`, `doc/README.md`,
  `doc/INSTALLATION.md` and `pyproject.toml`. They pointed either at
  `CERN/pytlwall` or at the former `TLWallNew` name.
- Correct the documented CLI: batch mode requires `-a` (or a bare `.cfg`
  path), not a positional argument after the module name.
- Document that batch mode needs `[output]` / `[outputN]` / `[img_outputN]`
  sections, and that relative output paths resolve against the working
  directory unless `[path_info] main_path` is set.
- Add a virtual environment section covering PEP 668
  (`error: externally-managed-environment`).
- Add a `Testing` section describing how to run the suite and what to expect.
- Extend the troubleshooting table with the failure modes encountered here.
- Sync `doc/API_REFERENCE_CFGIO.md` with the restored methods.

## Verification

Full suite on a clean virtual environment:

```
362 passed, 3 skipped
```

End-to-end batch run from a fresh `pip install`:

```bash
python -m pytlwall -a examples/ex_run_exec/ex_lowbeta.cfg
```

produces `low_beta.xlsx`, `low_beta_long.txt` and `low_beta_long.png` in
`examples/ex_run_exec/`, as documented.

## Not included

Two pre-existing issues were left untouched to keep this PR focused:

- The package declares version `1.0.0` in `_version.py` and `pyproject.toml`,
  while the README documents the refactored code as v2.0.
- `setup.py` duplicates the metadata already in `pyproject.toml`, giving two
  sources of truth that will drift apart.