### PR TITLE
Document the configuration-file examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ freqs = pytlwall.Frequencies(fmin=3, fmax=9, fstep=2)
 
 | Document | Description |
 |----------|-------------|
-| [EXAMPLES_README.md](doc/EXAMPLES_README.md) | Examples overview |
+| [examples/README.md](examples/README.md) | Configuration-file examples: index |
+| [EXAMPLES.md](doc/EXAMPLES.md) | Python API examples: overview |
 | [EXAMPLES_BEAM.md](doc/EXAMPLES_BEAM.md) | Beam examples |
 | [EXAMPLES_FREQUENCIES.md](doc/EXAMPLES_FREQUENCIES.md) | Frequencies examples |
 | [EXAMPLES_LAYER.md](doc/EXAMPLES_LAYER.md) | Layer examples |
@@ -341,6 +342,7 @@ freqs = pytlwall.Frequencies(fmin=3, fmax=9, fstep=2)
 | [EXAMPLES_TLWALL.md](doc/EXAMPLES_TLWALL.md) | TlWall examples |
 | [EXAMPLES_MULTIPLE.md](doc/EXAMPLES_MULTIPLE.md) | MultipleChamber examples |
 | [EXAMPLES_LOGGING.md](doc/EXAMPLES_LOGGING.md) | Logging examples |
+| [EXAMPLES_WAKE.md](doc/EXAMPLES_WAKE.md) | Wake examples |
 
 ### Time-Domain Wake
 
@@ -348,7 +350,7 @@ freqs = pytlwall.Frequencies(fmin=3, fmax=9, fstep=2)
 |----------|-------------|
 | [WAKE.md](doc/WAKE.md) | Time-domain wake module (`TLWallWake`) overview and usage |
 | [WAKE_THEORY.md](doc/WAKE_THEORY.md) | Physical model: transmission-line wake and thick/thin limits |
-| [test_tlwall_wake.md](doc/testing/test_tlwall_wake.md) | Wake module test suite |
+| [test_tlwall_wake.md](tests/doc/test_tlwall_wake.md) | Wake module test suite |
 
 ### Additional Documentation
 
@@ -453,7 +455,7 @@ pytest
 Expected result on a clean checkout:
 
 ```
-362 passed, 3 skipped
+362 passed, 3 skipped, 40 subtests passed
 ```
 
 The three skips are expected: `tests/test_cfgio_realistic.py` contains cases
@@ -493,9 +495,10 @@ MPLBACKEND=Agg pytest
 
 ### Test documentation
 
-Individual test modules are documented under `tests/doc/`, for example
-[test_cfg.md](tests/doc/test_cfg.md) and
-[test_tlwall_wake.md](doc/testing/test_tlwall_wake.md).
+Individual test modules are documented under `tests/doc/`, starting from
+[TESTING.md](tests/doc/TESTING.md) and [tests_README.md](tests/doc/tests_README.md);
+see for example [test_cfg.md](tests/doc/test_cfg.md) and
+[test_tlwall_wake.md](tests/doc/test_tlwall_wake.md).
 
 ---
 
@@ -520,7 +523,7 @@ Individual test modules are documented under `tests/doc/`, for example
 ### Getting Help
 
 1. Check the [API Reference](doc/API_REFERENCE.md)
-2. Review the [Examples](doc/EXAMPLES_README.md)
+2. Review the [Examples](examples/README.md)
 3. Contact the authors
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,81 @@
+# Examples
+
+Configuration-driven examples. Each folder holds one or more `.cfg` files and
+a `README.md` describing the chamber, the beam and how to run it.
+
+For the **Python API** — using `Beam`, `Frequencies`, `Layer`, `Chamber`,
+`TlWall` and `MultipleChamber` directly from code — see the module guides
+under [`doc/`](../doc/EXAMPLES.md) instead. The two sets are complementary:
+this directory covers the configuration-file workflow, `doc/EXAMPLES_*.md`
+covers the programmatic one.
+
+## Frequency-domain examples
+
+| Folder | What it shows | Batch |
+|--------|---------------|:-----:|
+| [`ex_CW`](ex_CW/README.md) | Thin coating on a highly conductive wall | — |
+| [`ex_CWMag`](ex_CWMag/README.md) | Dispersive magnetic boundary | — |
+| [`ex_PEC`](ex_PEC/README.md) | Two layers on a perfect conductor; hand-written and machine-written configurations | — |
+| [`ex_Vac`](ex_Vac/README.md) | Same wall closed by semi-infinite vacuum | — |
+| [`ex_lowbeta`](ex_lowbeta/README.md) | Slow beam, dominant space charge | — |
+| [`ex_run_exec`](ex_run_exec/README.md) | **Full batch pipeline from the command line** | ✅ |
+| [`ex_surface_impedance`](ex_surface_impedance/README.md) | Equivalent surface impedance of a wall | — |
+| [`ex_surface_impedance_input`](ex_surface_impedance_input/README.md) | Surface impedance read from a text file | — |
+| [`ex_multiple`](ex_multiple/README.md) | Impedance accumulated over a lattice of elements | — |
+| [`ex_ferrite_kicker`](ex_ferrite_kicker/README.md) | **Four-layer kicker: coating, ceramic, vacuum gap, ferrite** | ✅ |
+
+## Time-domain examples
+
+| Folder | What it shows | Batch |
+|--------|---------------|:-----:|
+| [`ex_wake_pec`](ex_wake_pec/README.md) | Wake functions, perfect conductor boundary | — |
+| [`ex_wake_vacuum`](ex_wake_vacuum/README.md) | Wake functions, vacuum boundary | — |
+
+## Reading the "Batch" column
+
+Only the two marked folders can be executed directly from the command line:
+
+```bash
+python -m pytlwall -a examples/ex_run_exec/ex_lowbeta.cfg
+```
+
+Batch mode runs the whole pipeline — build the chamber, compute the
+impedances, write the data files, produce the plots — and it needs the
+configuration to declare what to produce, through `[output]`, `[outputN]` and
+`[img_outputN]` sections.
+
+The other configurations define a valid **model** but no output, so a batch
+run exits with a warning and writes nothing. They are meant to be loaded from
+their driver script in `examples/`, or from your own code:
+
+```python
+from pytlwall import CfgIo
+
+wall = CfgIo("examples/ex_CW/ex_CW.cfg").read_pytlwall()
+ZLong = wall.ZLong
+```
+
+Adding the missing sections to any of them is enough to make it runnable;
+[`ex_run_exec`](ex_run_exec/README.md) is the template to copy from.
+
+## Suggested reading order
+
+1. [`ex_run_exec`](ex_run_exec/README.md) — see the whole pipeline work
+2. [`ex_PEC`](ex_PEC/README.md) and [`ex_Vac`](ex_Vac/README.md) — the effect
+   of the outer boundary
+3. [`ex_CWMag`](ex_CWMag/README.md) — dispersive magnetic materials
+4. [`ex_ferrite_kicker`](ex_ferrite_kicker/README.md) — everything combined in
+   a realistic four-layer element
+
+## Conventions
+
+- `fmin` and `fmax` are **decimal exponents**, not frequencies: `fmin = 3`
+  means 10³ Hz. `fstep` sets the point density, and larger values give more
+  points.
+- Relative output paths resolve against the **working directory**, unless the
+  configuration declares `main_path` in a `[path_info]` section. Run the
+  examples from the repository root.
+- Generated results under `examples/*/output/`, `examples/*/img/` and
+  `examples/*/sav/` are excluded from version control.
+- `sigmaDC = 0` is not admitted; use a negligible value such as `1e-12` for an
+  insulator.

--- a/examples/ex_CW/README.md
+++ b/examples/ex_CW/README.md
@@ -1,0 +1,39 @@
+# Coated wall (`ex_CW`)
+
+Circular chamber with a thin resistive coating, closed by a highly conductive
+wall rather than by a perfect conductor. The reference case for a coated-wall
+geometry.
+
+## Chamber
+
+Radius **18.4 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 0.5 µm | 10⁶ S/m |
+| `boundary` (`CW`) | semi-infinite | 10⁹ S/m |
+
+Both layers are non-magnetic and non-dispersive.
+
+## Beam
+
+`gammarel = 10000`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 12, i.e. 1 Hz to 10¹² Hz.
+
+## Running
+
+```bash
+python examples/ex_CW.py
+```
+
+The configuration has no `[output]` section, so it cannot be run with
+`python -m pytlwall -a`. Use the driver script, or load it from Python:
+
+```python
+from pytlwall import CfgIo
+wall = CfgIo("examples/ex_CW/ex_CW.cfg").read_pytlwall()
+ZLong = wall.ZLong
+```

--- a/examples/ex_CWMag/README.md
+++ b/examples/ex_CWMag/README.md
@@ -1,0 +1,33 @@
+# Coated wall with magnetic boundary (`ex_CWMag`)
+
+Same structure as [`ex_CW`](../ex_CW/README.md), but the outer boundary is a
+**dispersive magnetic material**. Use this case to see how a magnetic boundary
+changes the impedance with respect to a purely resistive one.
+
+## Chamber
+
+Radius **24.25 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity | Magnetic properties |
+|-------|-----------|--------------|---------------------|
+| `layer0` | 1 mm | 1.670007·10⁶ S/m | non-magnetic |
+| `boundary` (`CW`) | semi-infinite | 10⁶ S/m | µ_inf = 500, f_relax = 10 kHz |
+
+The boundary permeability follows a single-pole relaxation model: `muinf_Hz`
+is the initial relative permeability, `k_Hz` the relaxation frequency.
+
+## Beam
+
+`gammarel = 10000`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 2 to 11, i.e. 100 Hz to 10¹¹ Hz.
+
+## Running
+
+```bash
+python examples/ex_CWMag.py
+```
+
+No `[output]` section, so `python -m pytlwall -a` does not apply.

--- a/examples/ex_PEC/README.md
+++ b/examples/ex_PEC/README.md
@@ -1,0 +1,40 @@
+# Perfect conductor boundary (`ex_PEC`)
+
+Two-layer chamber closed by a perfect electric conductor. This folder holds
+**two configurations describing the same physics**.
+
+| File | Origin |
+|------|--------|
+| `ex_PEC.cfg` | hand-written, with comments |
+| `ex_PEC2.cfg` | written back out by `CfgIo`, uncommented |
+
+`ex_PEC2.cfg` is useful as a round-trip reference: it shows the exact layout
+the package produces when saving a configuration, including empty keys in the
+`[boundary]` section and an empty `freq_file` entry. Both files give identical
+results.
+
+## Chamber
+
+Radius **18.4 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 50 µm | 1.82·10⁹ S/m |
+| `layer1` | 1 mm | 1.67·10⁶ S/m |
+| `boundary` | PEC | — |
+
+## Beam
+
+`gammarel = 10000`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 13, i.e. 1 Hz to 10¹³ Hz.
+
+## Running
+
+```bash
+python examples/ex_PEC.py
+```
+
+No `[output]` section in either file, so `python -m pytlwall -a` does not apply.

--- a/examples/ex_Vac/README.md
+++ b/examples/ex_Vac/README.md
@@ -1,0 +1,31 @@
+# Vacuum boundary (`ex_Vac`)
+
+Single resistive layer backed by semi-infinite vacuum. Together with
+[`ex_PEC`](../ex_PEC/README.md) this is the natural pair for studying the
+effect of the outer boundary condition: same kind of wall, opposite closure.
+
+## Chamber
+
+Radius **18.4 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 1 mm | 1.67·10⁶ S/m |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+## Beam
+
+`gammarel = 10000`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 15, i.e. 1 Hz to 10¹⁵ Hz — the widest range of the
+example set.
+
+## Running
+
+```bash
+python examples/ex_Vac.py
+```
+
+No `[output]` section, so `python -m pytlwall -a` does not apply.

--- a/examples/ex_ferrite_kicker/01_ferrite_kicker.cfg
+++ b/examples/ex_ferrite_kicker/01_ferrite_kicker.cfg
@@ -1,0 +1,155 @@
+; =============================================================================
+; Ferrite kicker - four-layer chamber
+; =============================================================================
+;
+; Layer stack, from the beam outwards:
+;
+;   layer0   titanium coating    1 um
+;   layer1   ceramic tube        5 mm
+;   layer2   vacuum gap          2 mm
+;   layer3   ferrite yoke       15 mm
+;   boundary perfect conductor
+;
+; Any property not stated explicitly below keeps the pytlwall default for a
+; non-magnetic, non-dispersive material (muinf_Hz = 0, k_Hz = inf, epsr = 1,
+; tau = 0, RQ = 0).
+;
+; Evaluated at unit length and beta = 1.
+; Originally generated as a WIMBA debug dump.
+; =============================================================================
+
+[base_info]
+component_name = ferrite_kicker
+chamber_shape = CIRCULAR
+; beam pipe radius: 10 mm
+pipe_radius_m = 0.01
+pipe_len_m = 1.0
+betax = 1.0
+betay = 1.0
+
+[layers_info]
+nbr_layers = 4
+
+; -----------------------------------------------------------------------------
+; layer0 - TITANIUM coating
+; Thin resistive coating deposited on the inner face of the ceramic tube.
+; -----------------------------------------------------------------------------
+[layer0]
+type = CW
+; 1 um
+thick_m = 1e-06
+; 2e6 S/m
+sigmaDC = 2000000.0
+muinf_Hz = 0.0
+k_Hz = inf
+epsr = 1.0
+tau = 0.0
+RQ = 0.0
+
+; -----------------------------------------------------------------------------
+; layer1 - CERAMIC tube
+; Insulating support: conductivity is set to a negligible non-zero value
+; because sigmaDC = 0 is not admitted.
+; -----------------------------------------------------------------------------
+[layer1]
+type = CW
+; 5 mm
+thick_m = 0.005
+; effectively an insulator
+sigmaDC = 1e-12
+muinf_Hz = 0.0
+k_Hz = inf
+; relative permittivity 9
+epsr = 9.0
+tau = 0.0
+RQ = 0.0
+
+; -----------------------------------------------------------------------------
+; layer2 - VACUUM gap
+; Air/vacuum spacing between the ceramic tube and the ferrite yoke.
+; -----------------------------------------------------------------------------
+[layer2]
+type = V
+; 2 mm
+thick_m = 0.002
+
+; -----------------------------------------------------------------------------
+; layer3 - FERRITE yoke
+; Dispersive magnetic material, described by a single-pole permeability model:
+; initial permeability muinf_Hz with relaxation frequency k_Hz.
+; -----------------------------------------------------------------------------
+[layer3]
+type = CW
+; 15 mm
+thick_m = 0.015
+; 1e-4 S/m
+sigmaDC = 0.0001
+; initial relative permeability
+muinf_Hz = 460.0
+; relaxation frequency: 20 MHz
+k_Hz = 20000000.0
+; relative permittivity 12
+epsr = 12.0
+tau = 0.0
+RQ = 0.0
+
+; -----------------------------------------------------------------------------
+; boundary - PERFECT ELECTRIC CONDUCTOR
+; Closes the stack: no field penetrates beyond the ferrite.
+; -----------------------------------------------------------------------------
+[boundary]
+type = PEC
+
+[beam_info]
+; ultrarelativistic proton beam
+gammarel = 7000.0
+test_beam_shift = 0.001
+
+[frequency_info]
+; fmin and fmax are decimal exponents: the grid spans 10^2 Hz to 10^10 Hz.
+; fstep sets the point density; larger values give more points.
+; This configuration yields 7200 frequencies from 101 Hz to 10 GHz.
+fmin = 2
+fmax = 10
+fstep = 3
+
+[output]
+ZLong = True
+ZTrans = True
+ZDipX = True
+ZDipY = True
+ZQuadX = True
+ZQuadY = True
+ZLongSurf = True
+ZTransSurf = True
+ZLongDSC = True
+ZLongISC = True
+ZTransDSC = True
+ZTransISC = True
+
+; Output paths are relative to the working directory, so run this example
+; from the repository root.
+[output1]
+output_name = examples/ex_ferrite_kicker/output/ferrite_kicker.xlsx
+use_name_flag = True
+output_list = ZLong, ZTrans, ZDipX, ZDipY, ZQuadX, ZQuadY, ZLongSurf,
+              ZTransSurf, ZLongDSC, ZLongISC, ZTransDSC, ZTransISC
+re_im_flag = both
+
+[img_output1]
+img_name = examples/ex_ferrite_kicker/img/ZLong.png
+use_name_flag = False
+imped_list = ZLong
+re_im_flag = both
+title = Longitudinal impedance - ferrite kicker
+xscale = log
+yscale = symlog
+
+[img_output2]
+img_name = examples/ex_ferrite_kicker/img/ZDip.png
+use_name_flag = False
+imped_list = ZDipX, ZDipY
+re_im_flag = both
+title = Dipolar impedance - ferrite kicker
+xscale = log
+yscale = symlog

--- a/examples/ex_ferrite_kicker/README.md
+++ b/examples/ex_ferrite_kicker/README.md
@@ -1,0 +1,91 @@
+# Ferrite kicker example
+
+A four-layer circular chamber representing a ferrite kicker: a titanium-coated
+ceramic tube, a vacuum gap, and a ferrite yoke closed by a perfect conductor.
+
+This is the most complex configuration shipped with the package. It exercises
+several features at once — multiple layers, a dispersive magnetic material, a
+vacuum layer between two solid ones, and a PEC boundary — which makes it a
+useful reference case when comparing implementations.
+
+## Chamber
+
+Beam pipe radius: **10 mm**. Length 1 m, `betax = betay = 1`, so the result is
+an impedance per metre at unit beta function.
+
+| Layer | Material | Thickness | Key properties |
+|-------|----------|-----------|----------------|
+| `layer0` | Titanium coating | 1 µm | σ = 2·10⁶ S/m |
+| `layer1` | Ceramic tube | 5 mm | ε_r = 9, σ = 10⁻¹² S/m |
+| `layer2` | Vacuum gap | 2 mm | — |
+| `layer3` | Ferrite yoke | 15 mm | µ_inf = 460, f_relax = 20 MHz, ε_r = 12, σ = 10⁻⁴ S/m |
+| `boundary` | PEC | — | perfect electric conductor |
+
+Layers are ordered from the beam outwards. Any property not stated explicitly
+in the configuration keeps the pytlwall default for a non-magnetic,
+non-dispersive material.
+
+Two conventions are worth noting:
+
+- The ceramic conductivity is set to `1e-12` rather than zero, because
+  `sigmaDC = 0` is not admitted by the layer model.
+- The ferrite permeability follows a single-pole relaxation model: `muinf_Hz`
+  is the initial relative permeability and `k_Hz` the relaxation frequency.
+
+## Beam
+
+Ultrarelativistic protons, `gammarel = 7000`, transverse test offset 1 mm.
+
+## Frequency grid
+
+`fmin` and `fmax` are decimal exponents, so the grid spans 10² Hz to 10¹⁰ Hz.
+`fstep = 3` sets the point density — larger values give more points. This
+configuration produces **7200 frequencies** from 101 Hz to 10 GHz, which is why
+the run takes noticeably longer than the other examples.
+
+## Running
+
+From the repository root:
+
+```bash
+python -m pytlwall -a examples/ex_ferrite_kicker/01_ferrite_kicker.cfg
+```
+
+Output paths in the configuration are relative to the working directory, so
+running from elsewhere will place the results elsewhere. To run from an
+arbitrary directory, add a `[path_info]` section with `main_path` set to the
+repository root.
+
+## Output
+
+```
+examples/ex_ferrite_kicker/
+├── output/
+│   └── ferrite_kicker.xlsx     all twelve impedances, real and imaginary
+└── img/
+    ├── ZLong.png               longitudinal impedance
+    └── ZDip.png                horizontal and vertical dipolar impedance
+```
+
+Both directories are created automatically on the first run and are excluded
+from version control by the repository `.gitignore`, along with the other
+`examples/*/output/` and `examples/*/img/` paths.
+
+## Expected magnitudes
+
+Longitudinal impedance, for a quick sanity check after a change:
+
+| f [Hz] | Re(ZLong) [Ω] | Im(ZLong) [Ω] |
+|--------|---------------|---------------|
+| 10³ | 5.83·10⁻² | 1.34·10⁻¹ |
+| 10⁵ | 7.89 | 7.23·10⁻¹ |
+| 10⁶ | 7.95 | 7.33·10⁻² |
+| 10⁷ | 7.95 | 7.62·10⁻³ |
+| 10⁸ | 7.95 | 3.36·10⁻³ |
+| 10⁹ | 7.96 | 4.09·10⁻² |
+
+The real part rises through the low-frequency range and then flattens above
+roughly 10⁵ Hz, while the imaginary part falls away over the same interval.
+
+These values are recorded as a regression baseline for this implementation,
+not as an independently validated physical result.

--- a/examples/ex_lowbeta/README.md
+++ b/examples/ex_lowbeta/README.md
@@ -1,0 +1,32 @@
+# Low-beta beam (`ex_lowbeta`)
+
+A slow, non-ultrarelativistic beam. At `gammarel = 2.49` the space-charge
+contributions are large, which makes this the reference case for the direct
+and indirect space-charge impedances (`ZLongDSC`, `ZLongISC`, `ZTransDSC`,
+`ZTransISC`).
+
+## Chamber
+
+Radius **35 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 1.5 mm | 833333 S/m |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+## Beam
+
+`gammarel = 2.49`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 10, i.e. 1 Hz to 10¹⁰ Hz.
+
+## Running
+
+```bash
+python examples/ex_lowbeta.py
+```
+
+No `[output]` section here. The same chamber **with** output sections, ready
+for batch execution, is in [`ex_run_exec`](../ex_run_exec/README.md).

--- a/examples/ex_multiple/README.md
+++ b/examples/ex_multiple/README.md
@@ -1,0 +1,41 @@
+# Multi-chamber lattice (`ex_multiple`)
+
+Accumulates the impedance of a whole sequence of elements through
+`pytlwall.MultipleChamber`, rather than treating a single chamber. Each element
+of the lattice is assigned a chamber type, and its own geometry and optics.
+
+## Files
+
+| File | Role |
+|------|------|
+| `apertype2.txt` | chamber type of each element, one per line |
+| `b_L_betax_betay.txt` | radius, length and beta functions per element |
+| `Round.cfg`, `Oblong.cfg`, `Rectangular.cfg`, `Diamond.cfg` | material definition per chamber type |
+
+`apertype2.txt` lists **10 elements** using three types: `round`, `oblong`
+and `rectangular`. `b_L_betax_betay.txt` carries the matching 10 rows of
+geometry and optics, after a two-line comment header.
+
+## Chamber types
+
+| Type | Shape | Layers |
+|------|-------|--------|
+| `Round`, `Oblong` | circular, radius 18.4 mm | 50 µm at 1.82·10⁹ S/m, then a second layer |
+| `Rectangular`, `Diamond` | rectangular, 31.5 × 11.5 mm | single layer, 0.4 mm |
+
+Note that `betarel` is used here instead of `gammarel`: 1.0 for the circular
+types and 0.916 for the rectangular ones. The transverse test offset is 3 mm.
+
+## Known redundancy
+
+`Diamond.cfg` is byte-identical to `Rectangular.cfg`, and `Oblong.cfg` to
+`Round.cfg`. Since `apertype2.txt` never requests a `diamond` element,
+`Diamond.cfg` is unused by this example. The duplicates are kept because the
+file names are what `MultipleChamber` looks up by chamber type; they are
+placeholders awaiting distinct definitions, not four independent cases.
+
+## Running
+
+```bash
+python examples/example_multiple_chamber.py
+```

--- a/examples/ex_run_exec/README.md
+++ b/examples/ex_run_exec/README.md
@@ -1,0 +1,49 @@
+# Batch execution (`ex_run_exec`)
+
+The reference example for the **command-line batch mode**. Physically it is
+the same chamber as [`ex_lowbeta`](../ex_lowbeta/README.md); what differs is
+that this configuration declares `[output]`, `[output1]`, `[output2]` and
+`[img_output1]` sections, so the full pipeline runs end to end without writing
+any Python.
+
+Use it as the template when writing your own runnable configuration.
+
+## Chamber
+
+Radius **35 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 1.5 mm | 833333 S/m |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+## Beam
+
+`gammarel = 2.49`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 10, i.e. 1 Hz to 10¹⁰ Hz.
+
+## Running
+
+From the repository root:
+
+```bash
+python -m pytlwall -a examples/ex_run_exec/ex_lowbeta.cfg
+```
+
+## Output
+
+Written into this folder:
+
+| File | Content |
+|------|---------|
+| `low_beta.xlsx` | all twelve impedances, real and imaginary |
+| `low_beta_long.txt` | `ZLong`, `ZLongSurf`, `ZLongDSC`, `ZLongISC` |
+| `low_beta_long.png` | longitudinal impedance plot |
+
+All three are excluded from version control.
+
+Output paths in the configuration are relative to the working directory, so
+run this from the repository root or the files will land elsewhere.

--- a/examples/ex_surface_impedance/README.md
+++ b/examples/ex_surface_impedance/README.md
@@ -1,0 +1,37 @@
+# Equivalent surface impedance (`ex_surface_impedance`)
+
+Demonstrates the **equivalent surface impedance** of a wall: `ZLongSurf` and
+`ZTransSurf`, the quantities that condense a multilayer stack into a single
+surface property.
+
+The chamber is identical to [`ex_lowbeta`](../ex_lowbeta/README.md); what the
+example adds is the extraction and plotting of the surface quantities rather
+than the coupling impedances.
+
+## Chamber
+
+Radius **35 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 1.5 mm | 833333 S/m |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+## Beam
+
+`gammarel = 2.49`, transverse test offset 10 mm.
+
+## Frequency grid
+
+Decimal exponents 0 to 10, i.e. 1 Hz to 10¹⁰ Hz.
+
+## Running
+
+```bash
+python examples/ex_surface_impedance.py
+```
+
+The natural counterpart is
+[`ex_surface_impedance_input`](../ex_surface_impedance_input/README.md), which
+goes the other way: it reads a surface impedance from file instead of
+computing it.

--- a/examples/ex_surface_impedance_input/README.md
+++ b/examples/ex_surface_impedance_input/README.md
@@ -1,0 +1,37 @@
+# Surface impedance from file (`ex_surface_impedance_input`)
+
+The inverse of [`ex_surface_impedance`](../ex_surface_impedance/README.md):
+instead of computing the surface impedance from the layer properties, it is
+**read from a text file** and applied to the layer. Use this when the wall
+response comes from a measurement or from an external code.
+
+## Files
+
+| File | Content |
+|------|---------|
+| `ex_surface_impedance_input.cfg` | chamber, beam and frequency definition |
+| `surface_impedance_input.txt` | tabulated surface impedance |
+
+The text file has a two-line header followed by three columns: frequency in
+Hz, then the real and imaginary parts of the surface impedance.
+
+## Chamber
+
+Radius **35 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 1.5 mm | 833333 S/m |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+The layer properties are overridden by the tabulated surface impedance.
+
+## Beam
+
+`gammarel = 2.49`, transverse test offset 10 mm.
+
+## Running
+
+```bash
+python examples/ex_surface_impedance_input.py
+```

--- a/examples/ex_wake_pec/README.md
+++ b/examples/ex_wake_pec/README.md
@@ -1,0 +1,39 @@
+# Time-domain wake, PEC boundary (`ex_wake_pec`)
+
+A **time-domain** case: it computes wake functions rather than impedances,
+through the `TLWallWake` class. Selected by `CalcWake = wake` in the
+`[calc_info]` section, which replaces `[frequency_info]` with `[time_info]`.
+
+## Chamber
+
+Radius **22 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 2 mm | 5.96·10⁷ S/m (copper) |
+| `boundary` | PEC | — |
+
+## Beam
+
+`gammarel = 7460.52`, transverse test offset 10 mm.
+
+## Time grid
+
+Decimal exponents −12 to −1, i.e. 1 ps to 100 ms, over **1401 logarithmically
+spaced points**.
+
+## Running
+
+```bash
+python examples/ex_wake.py
+```
+
+The driver runs this case together with
+[`ex_wake_vacuum`](../ex_wake_vacuum/README.md) and compares the two boundary
+conditions on the same wall.
+
+## Further reading
+
+- [WAKE.md](../../doc/WAKE.md) — module overview and usage
+- [WAKE_THEORY.md](../../doc/WAKE_THEORY.md) — transmission-line wake, thick
+  and thin wall limits

--- a/examples/ex_wake_vacuum/README.md
+++ b/examples/ex_wake_vacuum/README.md
@@ -1,0 +1,37 @@
+# Time-domain wake, vacuum boundary (`ex_wake_vacuum`)
+
+Identical to [`ex_wake_pec`](../ex_wake_pec/README.md) except for the outer
+boundary, which here is semi-infinite vacuum instead of a perfect conductor.
+The two cases exist to be compared: same wall, opposite closure.
+
+## Chamber
+
+Radius **22 mm**, length 1 m, `betax = betay = 1`.
+
+| Layer | Thickness | Conductivity |
+|-------|-----------|--------------|
+| `layer0` | 2 mm | 5.96·10⁷ S/m (copper) |
+| `boundary` (`V`) | semi-infinite vacuum | — |
+
+## Beam
+
+`gammarel = 7460.52`, transverse test offset 10 mm.
+
+## Time grid
+
+Decimal exponents −12 to −1, i.e. 1 ps to 100 ms, over **1401 logarithmically
+spaced points**.
+
+## Running
+
+```bash
+python examples/ex_wake.py
+```
+
+The driver computes both boundary conditions and plots them together.
+
+## Further reading
+
+- [WAKE.md](../../doc/WAKE.md) — module overview and usage
+- [WAKE_THEORY.md](../../doc/WAKE_THEORY.md) — transmission-line wake, thick
+  and thin wall limits


### PR DESCRIPTION
Add an index under examples/ plus a README for each of the twelve example folders, describing chamber, beam, frequency or time grid, and how to run each case. Mark which configurations support batch execution.

Add the four-layer ferrite kicker example.

Fix broken documentation links in the main README: doc/EXAMPLES_README.md does not exist, and the wake test documentation lives under tests/doc/.